### PR TITLE
Demonstrates NPE when accessing f^.n

### DIFF
--- a/src/test/java/cz/cuni/mff/d3s/trupple/PointersTest.java
+++ b/src/test/java/cz/cuni/mff/d3s/trupple/PointersTest.java
@@ -155,4 +155,25 @@ public class PointersTest extends JUnitTest {
         testWithInput(code, "lemmiF sivarT", "Travis Fimmel", true);
     }
 
+    @Test
+    public void modOnPointer() {
+        String code = "program main;\n"+
+                "\n"+
+                "type pnode = ^node;\n"+
+                "node = record\n"+
+                " previous: pnode;\n"+
+                " value: integer;\n"+
+                "end;\n"+
+                "function filterAndAdd(root: pnode; number: integer): boolean;\n" +
+                "var d: integer;\n"+
+                "begin\n"+
+                "  d := number mod f^.n;\n"+
+                "  filterAndAdd := d = 0;\n"+
+                "end;\n"+
+                "begin\n" +
+                "end.";
+
+        testWithInput(code, "lemmiF sivarT", "", true);
+    }
+
 }


### PR DESCRIPTION
The test seems to fail with:
```
modOnPointer(cz.cuni.mff.d3s.trupple.PointersTest)  Time elapsed: 0.025 sec  <<< ERROR!
java.lang.NullPointerException
	at cz.cuni.mff.d3s.trupple.parser.NodeFactory.createReadDereferenceNode(NodeFactory.java:1022)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.ReadRouteElement(Parser.java:1189)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.InnerReadRouteNonEmpty(Parser.java:1170)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.InnerIdentifierAccess(Parser.java:1163)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.IdentifierAccess(Parser.java:1127)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Factor(Parser.java:1080)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.SignedFactor(Parser.java:1070)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Term(Parser.java:1051)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Arithmetic(Parser.java:1023)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.LogicFactor(Parser.java:978)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.SignedLogicFactor(Parser.java:971)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.LogicTerm(Parser.java:952)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Expression(Parser.java:875)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Assignment(Parser.java:867)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.IdentifierBeginningStatement(Parser.java:840)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Statement(Parser.java:724)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.StatementSequence(Parser.java:665)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Block(Parser.java:603)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Function(Parser.java:579)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Subroutine(Parser.java:244)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Declaration(Parser.java:192)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Declarations(Parser.java:147)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Pascal(Parser.java:112)
	at cz.cuni.mff.d3s.trupple.parser.tp.Parser.Parse(Parser.java:1333)
	at cz.cuni.mff.d3s.trupple.language.PascalLanguage.parseSource(PascalLanguage.java:96)
	at cz.cuni.mff.d3s.trupple.language.PascalLanguage.parse(PascalLanguage.java:91)
	at com.oracle.truffle.api.TruffleLanguage$ParsingRequest.parse(TruffleLanguage.java:437)
	at com.oracle.truffle.api.TruffleLanguage.parse(TruffleLanguage.java:691)
```